### PR TITLE
Increase model size and training defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,18 @@ Superhuman Chess AI using a hybrid CNN+Transformer AlphaZero-style architecture.
    ```
 3. **Resume or start training:**
    ```sh
-   python dynamic_self_play.py
+   python src/training/alphazero_trainer.py
    ```
 4. **Launch the web GUI:**
    ```sh
-   python chess_web_gui.py
-   ```
+  python chess_web_gui.py
+  ```
+
+## Recommended Settings
+- The default configuration trains a ~64M parameter model with 384 CNN channels and 20 residual blocks.
+- Set `iterations` to 1000 and `games_per_iteration` to 50 for long runs.
+- Evaluation happens every 5 iterations with 20 games to promote the best model.
+- A GPU with at least **12 GB** of VRAM (e.g. RTX 3060) is recommended. CPU-only training is possible but very slow.
 
 ## Checkpoints
 - `models/alpha_zero_checkpoints/latest_player.pt`: Most recent player model

--- a/configs/config.v2.yaml
+++ b/configs/config.v2.yaml
@@ -13,7 +13,7 @@ model:
   # These values define the ~64M parameter architecture.
   chess_transformer:
     input_channels: 12
-    cnn_channels: 256
+    cnn_channels: 384
     cnn_blocks: 20
     transformer_layers: 8
     attention_heads: 8
@@ -25,18 +25,18 @@ training:
   # --- AlphaZero Training Loop ---
   # This section governs the new dynamic_self_play.py script.
   alpha_zero:
-    iterations: 1  # quick smoke-run
-    games_per_iteration: 2
-    epochs_per_iteration: 1
-    batch_size: 32
+    iterations: 1000
+    games_per_iteration: 50
+    epochs_per_iteration: 2
+    batch_size: 256
     
     # Replay Buffer
-    replay_buffer_size: 1000
-    min_replay_buffer_size: 0
+    replay_buffer_size: 500000
+    min_replay_buffer_size: 10000
 
     # Evaluation & Opponent Update
-    evaluation_interval: 0  # skip evaluation in smoke
-    evaluation_games: 0
+    evaluation_interval: 5
+    evaluation_games: 20
     opponent_update_threshold: 0.55 # Require a 55% win/draw rate to promote
 
     # Learning Rate
@@ -63,7 +63,7 @@ training:
 
   # --- MCTS (Monte Carlo Tree Search) ---
   mcts:
-    simulations: 20
+    simulations: 100
     c_puct: 1.5
     dirichlet_alpha: 0.6
     dirichlet_epsilon: 0.40
@@ -145,8 +145,8 @@ system:
   # Hardware acceleration: "cuda" or "cpu"
   device: "cuda" # run trainer on GPU
   compile_model: false
-  self_play_workers: 4
-  evaluation_workers: 2
+  self_play_workers: 5
+  evaluation_workers: 5
   dataloader_workers: 0  # torch DataLoader workers inside trainer
   use_manager_queue: true
 


### PR DESCRIPTION
## Summary
- expand CNN channels for ~64M param model
- restore full AlphaZero training settings
- bump default batch size
- document hardware requirements and training command in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586719d70c832385dd2e3ce93dbd3a