### PR TITLE
Add minimal test suite

### DIFF
--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+import chess
+import pytest
+
+# Skip entire module if torch is unavailable
+torch = pytest.importorskip("torch")
+
+from search.mcts import MCTS
+from utils.move_encoder import get_policy_vector_size
+from utils.board_utils import board_to_tensor
+from models.base_model import BaseModel
+
+
+class DummyModel(BaseModel):
+    def forward(self, x):
+        batch = x.shape[0]
+        value = torch.zeros(batch)
+        policy = torch.zeros(batch, get_policy_vector_size())
+        return value, policy
+
+
+def test_mcts_root_visit_count():
+    config = {
+        "training": {
+            "mcts": {
+                "simulations": 5,
+                "c_puct": 1.0,
+                "dirichlet_alpha": 0.0,
+                "dirichlet_epsilon": 0.0,
+            }
+        }
+    }
+    mcts = MCTS(DummyModel(), config, device="cpu")
+    board = chess.Board()
+    mcts.search(board, simulations=5)
+    assert mcts.root.visit_count == 6

--- a/tests/test_move_encoder.py
+++ b/tests/test_move_encoder.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+import chess
+from utils.move_encoder import encode_move, decode_move, get_policy_vector_size
+
+
+def test_move_encoder_round_trip():
+    size = get_policy_vector_size()
+    for idx in range(size):
+        move = decode_move(idx)
+        assert encode_move(move) == idx

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+import numpy as np
+import pytest
+
+# Skip if torch or webdataset not installed
+torch = pytest.importorskip("torch")
+pytest.importorskip("webdataset")
+
+from utils.replay_buffer import StreamingReplayBuffer
+from utils.move_encoder import get_policy_vector_size
+
+
+def test_replay_buffer_add_sample(tmp_path):
+    buf = StreamingReplayBuffer(tmp_path)
+    state = np.zeros((12, 8, 8), dtype=np.float32)
+    policy = np.zeros(get_policy_vector_size(), dtype=np.float32)
+    for v in [0.1, -0.2, 0.3]:
+        buf.add(state, policy, v)
+    assert len(buf) == 3
+    states, policies, values = buf.sample(2)
+    assert states.shape[0] == 2
+    assert policies.shape == (2, policy.size)
+    assert values.shape[0] == 2
+    buf.close()


### PR DESCRIPTION
## Summary
- add pytest-based tests for move encoding, MCTS stats and replay buffer
- place tests under `tests/`
- CI already runs `pytest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586c4ffc9c832383333cb0e408e146