### PR TITLE
Add seeding and verbose logging to MCTS

### DIFF
--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -39,3 +39,32 @@ def test_mcts_root_visit_count():
     board = chess.Board()
     mcts.search(board, simulations=5)
     assert mcts.root.visit_count == 6
+
+
+def test_mcts_deterministic_with_seed():
+    """MCTS should return the same results when seeded."""
+    config = {
+        "training": {
+            "mcts": {
+                "simulations": 1,
+                "c_puct": 1.0,
+                # Non-zero values introduce randomness via Dirichlet noise
+                "dirichlet_alpha": 0.3,
+                "dirichlet_epsilon": 0.25,
+            }
+        }
+    }
+    board = chess.Board()
+
+    seed = 42
+    mcts1 = MCTS(DummyModel(), config, device="cpu", random_seed=seed)
+    move1 = mcts1.search(board, simulations=1)
+
+    mcts2 = MCTS(DummyModel(), config, device="cpu", random_seed=seed)
+    move2 = mcts2.search(board, simulations=1)
+
+    assert move1 == move2
+
+    visits1 = {str(move): child.visit_count for move, child in mcts1.root.children.items()}
+    visits2 = {str(move): child.visit_count for move, child in mcts2.root.children.items()}
+    assert visits1 == visits2


### PR DESCRIPTION
## Summary
- allow seeding numpy and Python random in `MCTS` for deterministic behavior
- add optional verbose logging in MCTS search to show chosen moves, visits and evaluations
- test that fixed seeds yield consistent MCTS results

## Testing
- `pytest tests/test_mcts.py tests/test_move_encoder.py tests/test_replay_buffer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d620f77483238f608043aa2a2643