### PR TITLE
refactor: move inference helpers into engine

### DIFF
--- a/chess_web_gui.py
+++ b/chess_web_gui.py
@@ -28,7 +28,7 @@ from utils.move_encoder import get_policy_vector_size
 # Import MCTS for move generation
 # We need to import the classes, and the file itself to access the static methods
 from search.mcts import MCTS
-from src.training.alphazero_trainer import select_move
+from src.engine.inference_helpers import select_move
 
 # --- Configuration & Global Setup ---
 try:

--- a/src/engine/inference_helpers.py
+++ b/src/engine/inference_helpers.py
@@ -1,0 +1,52 @@
+import random
+from typing import Dict
+
+import chess
+import numpy as np
+from utils.move_encoder import encode_move
+
+
+def select_move(policy: np.ndarray, temperature: float, board: chess.Board) -> chess.Move:
+    """Select a legal move using the given policy and temperature."""
+    legal_moves_map: Dict[int, chess.Move] = {
+        encode_move(mv): mv for mv in board.legal_moves if encode_move(mv) is not None
+    }
+    if not legal_moves_map:
+        return random.choice(list(board.legal_moves)) if list(board.legal_moves) else None
+
+    legal_indices = list(legal_moves_map.keys())
+    legal_policy = policy[legal_indices]
+
+    if np.sum(legal_policy) == 0:
+        return legal_moves_map.get(random.choice(legal_indices))
+
+    if temperature == 0:
+        move_idx = legal_indices[int(np.argmax(legal_policy))]
+    else:
+        distribution = np.power(legal_policy, 1.0 / temperature)
+        distribution /= np.sum(distribution)
+        move_idx = np.random.choice(legal_indices, p=distribution)
+
+    return legal_moves_map.get(move_idx)
+
+
+def create_remote_evaluator(req_q, res_q, device="cpu"):
+    """Factory that returns an evaluator(board_tensor) callable using queues."""
+    import os
+    import torch
+    import numpy as np
+
+    def _eval(board_tensor: torch.Tensor):
+        uid = os.urandom(16)
+        req_q.put((uid, board_tensor.squeeze(0).cpu().numpy()))
+        while True:
+            try:
+                resp_uid, policy_np, value = res_q.get(timeout=120)
+            except Exception:
+                raise RuntimeError("Inference server timeout after 120s; check GPU server logs")
+            if resp_uid == uid:
+                policy = torch.from_numpy(np.asarray(policy_np)).float()
+                val = torch.tensor(value, dtype=torch.float32)
+                return val, policy
+
+    return _eval

--- a/src/engine/uci_server.py
+++ b/src/engine/uci_server.py
@@ -28,7 +28,7 @@ from models.chess_transformer import ChessTransformer
 from utils.config_loader import load_config
 from utils.move_encoder import get_policy_vector_size
 from search.mcts import MCTS
-from src.training.alphazero_trainer import select_move
+from engine.inference_helpers import select_move
 
 CONFIG = load_config("configs/config.v2.yaml")
 POLICY_SIZE = get_policy_vector_size()

--- a/src/training/alphazero_trainer.py
+++ b/src/training/alphazero_trainer.py
@@ -3,7 +3,6 @@ import torch.optim as optim
 import torch.nn.functional as F
 import chess
 import numpy as np
-import random
 import os
 import time
 import math
@@ -35,6 +34,7 @@ from utils.config_loader import load_config
 from utils.move_encoder import encode_move, decode_move, get_policy_vector_size
 from search.mcts import MCTS
 from utils.board_utils import board_to_tensor
+from engine.inference_helpers import select_move
 
 # --- Game Outcome Constants ---
 WIN = 1.0
@@ -970,56 +970,6 @@ class AlphaZeroTrainer:
                     f"Failed to load progress from {self.progress_file}: {e}. Starting with default values."
                 )
 
-
-# ------------------------------- Move Selection -------------------------------
-
-def select_move(policy: np.ndarray, temperature: float, board: chess.Board) -> chess.Move:
-    """Selects a legal move using the given policy and temperature."""
-    legal_moves_map = {
-        encode_move(mv): mv for mv in board.legal_moves if encode_move(mv) is not None
-    }
-    if not legal_moves_map:
-        return random.choice(list(board.legal_moves)) if list(board.legal_moves) else None
-
-    legal_indices = list(legal_moves_map.keys())
-    legal_policy = policy[legal_indices]
-
-    if np.sum(legal_policy) == 0:
-        return legal_moves_map.get(random.choice(legal_indices))
-
-    if temperature == 0:
-        move_idx = legal_indices[int(np.argmax(legal_policy))]
-    else:
-        distribution = np.power(legal_policy, 1.0 / temperature)
-        distribution /= np.sum(distribution)
-        move_idx = np.random.choice(legal_indices, p=distribution)
-
-    return legal_moves_map.get(move_idx)
-
-
-# --------------------------- Inference queue helpers --------------------------
-
-
-def create_remote_evaluator(req_q, res_q, device="cpu"):
-    """Factory that returns an evaluator(board_tensor) callable using queues."""
-    import os, torch, numpy as np
-
-    def _eval(board_tensor: torch.Tensor):
-        uid = os.urandom(16)
-        req_q.put((uid, board_tensor.squeeze(0).cpu().numpy()))
-        while True:
-            try:
-                resp_uid, policy_np, value = res_q.get(timeout=120)
-            except Exception:
-                raise RuntimeError(
-                    "Inference server timeout after 120s; check GPU server logs"
-                )
-            if resp_uid == uid:
-                policy = torch.from_numpy(np.asarray(policy_np)).float()
-                val = torch.tensor(value, dtype=torch.float32)
-                return val, policy
-
-    return _eval
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `inference_helpers` module with move selection and remote evaluation utilities
- update chess_web_gui and UCI server to import inference helpers from engine
- wire training loop to use engine-level move selection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chess')*
- `pip install -q numpy python-chess`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6896d6282ec8832393ea9b251adab568