### PR TITLE
Add context manager to StreamingReplayBuffer

### DIFF
--- a/src/training/alphazero_trainer.py
+++ b/src/training/alphazero_trainer.py
@@ -361,7 +361,11 @@ class AlphaZeroTrainer:
     7. Updates the "best" model if the new one is significantly better.
     """
 
-    def __init__(self, config_path="configs/config.v2.yaml"):
+    def __init__(
+        self,
+        config_path="configs/config.v2.yaml",
+        replay_buffer: StreamingReplayBuffer | None = None,
+    ):
         """Initializes the trainer, loading configuration and setting up components."""
         self.config = load_config(config_path)
         self.config_path = config_path
@@ -386,7 +390,7 @@ class AlphaZeroTrainer:
         # --- Training Components ---
         self.optimizer = self._create_optimizer()
         self.scheduler = self._create_scheduler()
-        self.replay_buffer = StreamingReplayBuffer(
+        self.replay_buffer = replay_buffer or StreamingReplayBuffer(
             root_dir=self.config["data"]["replay_buffer_dir"]
         )
 
@@ -1047,5 +1051,13 @@ if __name__ == "__main__":
     except RuntimeError:
         pass  # Already set
 
-    trainer = AlphaZeroTrainer(config_path="configs/config.v2.yaml")
-    trainer.run()
+    config_path = "configs/config.v2.yaml"
+    config = load_config(config_path)
+    with StreamingReplayBuffer(
+        root_dir=config["data"]["replay_buffer_dir"]
+    ) as replay_buffer:
+        trainer = AlphaZeroTrainer(
+            config_path=config_path,
+            replay_buffer=replay_buffer,
+        )
+        trainer.run()

--- a/src/utils/replay_buffer.py
+++ b/src/utils/replay_buffer.py
@@ -78,7 +78,20 @@ class StreamingReplayBuffer:
             self._games += 1
 
     def close(self):
-        self._writer.close()
+        """Flush and close the underlying shard writer."""
+        if self._writer is not None:
+            self._writer.close()
+            self._writer = None
+
+    # ------------------------------------------------------------------
+    # Context manager protocol
+    # ------------------------------------------------------------------
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
 
     # ------------------------------------------------------------------
     # Dataset helper
@@ -146,4 +159,4 @@ class StreamingReplayBuffer:
         return states, policies, values
 
     def __len__(self):
-        return self._written 
+        return self._written

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -7,8 +7,7 @@ sys.path.append(str(ROOT / "src"))
 import numpy as np
 import pytest
 
-# Skip if torch or webdataset not installed
-torch = pytest.importorskip("torch")
+# Skip if webdataset is not installed
 pytest.importorskip("webdataset")
 
 from utils.replay_buffer import StreamingReplayBuffer
@@ -16,14 +15,23 @@ from utils.move_encoder import get_policy_vector_size
 
 
 def test_replay_buffer_add_sample(tmp_path):
-    buf = StreamingReplayBuffer(tmp_path)
     state = np.zeros((12, 8, 8), dtype=np.float32)
     policy = np.zeros(get_policy_vector_size(), dtype=np.float32)
-    for v in [0.1, -0.2, 0.3]:
-        buf.add(state, policy, v)
-    assert len(buf) == 3
-    states, policies, values = buf.sample(2)
-    assert states.shape[0] == 2
-    assert policies.shape == (2, policy.size)
-    assert values.shape[0] == 2
-    buf.close()
+    with StreamingReplayBuffer(tmp_path) as buf:
+        for v in [0.1, -0.2, 0.3]:
+            buf.add(state, policy, v)
+        assert len(buf) == 3
+        torch = pytest.importorskip("torch")
+        states, policies, values = buf.sample(2)
+        assert states.shape[0] == 2
+        assert policies.shape == (2, policy.size)
+        assert values.shape[0] == 2
+
+
+def test_replay_buffer_context_closes(tmp_path):
+    state = np.zeros((12, 8, 8), dtype=np.float32)
+    policy = np.zeros(get_policy_vector_size(), dtype=np.float32)
+    with StreamingReplayBuffer(tmp_path) as buf:
+        buf.add(state, policy, 0.1)
+    with pytest.raises(AttributeError):
+        buf.add(state, policy, 0.2)


### PR DESCRIPTION
## Summary
- make StreamingReplayBuffer a context manager that closes the underlying shard writer
- update AlphaZero trainer to accept an injected replay buffer and use a context manager in the CLI entry point
- rewrite replay buffer tests to use the context manager and add a test ensuring the writer closes after exiting the block

## Testing
- `pytest tests/test_replay_buffer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d623b8b08323a7938c0f11f2f37b