### PR TITLE
Modularize training workflow with worker, MCTS, and loop components

### DIFF
--- a/src/training/__init__.py
+++ b/src/training/__init__.py
@@ -1,0 +1,5 @@
+"""Training utilities for RookNet."""
+
+# Modules are intentionally not imported here to avoid heavy dependencies at
+# package import time. Import from submodules directly, e.g.:
+# ``from training.worker import SelfPlayWorker``.

--- a/src/training/mcts_interface.py
+++ b/src/training/mcts_interface.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from typing import Optional, Any
+
+import chess
+
+from search.mcts import MCTS
+
+
+@dataclass
+class MCTSConfig:
+    """Configuration for MCTS interaction."""
+
+    simulations: int = 32
+    c_puct: float = 1.0
+
+    def to_dict(self) -> dict:
+        """Convert to a minimal config dict expected by :class:`search.mcts.MCTS`."""
+        return {
+            "training": {
+                "mcts": {
+                    "simulations": self.simulations,
+                    "c_puct": self.c_puct,
+                    "dirichlet_alpha": 0.0,
+                    "dirichlet_epsilon": 0.0,
+                }
+            }
+        }
+
+
+class MCTSRunner:
+    """Thin wrapper around :class:`search.mcts.MCTS` with structured config."""
+
+    def __init__(self, model: Any, config: Optional[MCTSConfig] = None, device: str = "cpu"):
+        self.config = config or MCTSConfig()
+        self.mcts = MCTS(model, self.config.to_dict(), device=device)
+
+    def select_move(self, board: chess.Board) -> chess.Move:
+        """Run MCTS search and return the selected move."""
+        return self.mcts.search(board, simulations=self.config.simulations)

--- a/src/training/training_loop.py
+++ b/src/training/training_loop.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from .worker import SelfPlayWorker
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration for the simple training loop."""
+
+    num_moves: int = 10
+
+
+@dataclass
+class TrainingState:
+    """State accumulated during training."""
+
+    moves: List[str] = field(default_factory=list)
+
+
+class TrainingLoop:
+    """Minimal training loop coordinating a worker."""
+
+    def __init__(self, worker: SelfPlayWorker, config: TrainingConfig):
+        self.worker = worker
+        self.config = config
+        self.state = TrainingState()
+
+    def run(self) -> TrainingState:
+        for _ in range(self.config.num_moves):
+            if self.worker.state.board.is_game_over():
+                break
+            move = self.worker.play_move()
+            self.state.moves.append(move.uci())
+        return self.state

--- a/src/training/worker.py
+++ b/src/training/worker.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+import chess
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from .mcts_interface import MCTSRunner
+
+
+@dataclass
+class WorkerState:
+    """Mutable state for a self-play worker."""
+
+    board: chess.Board
+
+
+class SelfPlayWorker:
+    """Worker that uses an MCTS-like object to play moves."""
+
+    def __init__(self, mcts: Any):
+        self.mcts = mcts
+        self.state = WorkerState(board=chess.Board())
+
+    def play_move(self) -> chess.Move:
+        """Select and play a move on the internal board."""
+        move = self.mcts.select_move(self.state.board)
+        self.state.board.push(move)
+        return move

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+import chess
+
+from training.training_loop import TrainingLoop, TrainingConfig
+from training.worker import SelfPlayWorker, WorkerState
+
+
+class DummyWorker(SelfPlayWorker):
+    def __init__(self):
+        # initialise with stub mcts; it won't be used
+        self.moves_played = 0
+        super().__init__(mcts=self)
+        self.state = WorkerState(board=chess.Board())
+
+    def select_move(self, board: chess.Board):  # type: ignore[override]
+        move = next(iter(board.legal_moves))
+        return move
+
+    def play_move(self):  # override to count
+        move = self.select_move(self.state.board)
+        self.state.board.push(move)
+        self.moves_played += 1
+        return move
+
+
+def test_training_loop_runs_moves():
+    worker = DummyWorker()
+    loop = TrainingLoop(worker, TrainingConfig(num_moves=2))
+    state = loop.run()
+    assert len(state.moves) == 2
+    assert worker.moves_played == 2

--- a/tests/test_training_mcts_interface.py
+++ b/tests/test_training_mcts_interface.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+import chess
+import pytest
+
+# Skip entire module if torch is unavailable
+torch = pytest.importorskip("torch")
+
+from training.mcts_interface import MCTSRunner, MCTSConfig
+from utils.move_encoder import get_policy_vector_size
+from models.base_model import BaseModel
+
+
+class DummyModel(BaseModel):
+    def forward(self, x):
+        batch = x.shape[0]
+        value = torch.zeros(batch)
+        policy = torch.zeros(batch, get_policy_vector_size())
+        return value, policy
+
+
+def test_mcts_runner_selects_legal_move():
+    board = chess.Board()
+    config = MCTSConfig(simulations=1, c_puct=1.0)
+    runner = MCTSRunner(DummyModel(), config, device="cpu")
+    move = runner.select_move(board)
+    assert move in board.legal_moves

--- a/tests/test_training_worker.py
+++ b/tests/test_training_worker.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+import chess
+
+from training.worker import SelfPlayWorker, WorkerState
+
+
+class StubMCTS:
+    def __init__(self, move: chess.Move):
+        self.move = move
+        self.called = 0
+
+    def select_move(self, board: chess.Board) -> chess.Move:
+        self.called += 1
+        return self.move
+
+
+def test_worker_plays_selected_move():
+    board = chess.Board()
+    move = next(iter(board.legal_moves))
+    worker = SelfPlayWorker(StubMCTS(move))
+    worker.state = WorkerState(board=board)
+    played = worker.play_move()
+    assert played == move
+    assert worker.mcts.called == 1
+    assert worker.state.board.move_stack[-1] == move


### PR DESCRIPTION
## Summary
- Add `MCTSConfig` and `MCTSRunner` to encapsulate MCTS configuration and search
- Introduce `SelfPlayWorker` with `WorkerState` to handle board updates via an MCTS-like object
- Create `TrainingLoop` with `TrainingConfig` and `TrainingState` for a structured training cycle
- Include unit tests for worker, loop, and MCTS interface modules

## Testing
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6896d62aa26c8323aa2905d246e2ea40