### PR TITLE
Add CLI subcommands for training, evaluation and web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@ Superhuman Chess AI using a hybrid CNN+Transformer AlphaZero-style architecture.
    source chess_ai_env/bin/activate
    pip install -e .[dev]
    ```
-3. **Resume or start training:**
+3. **Start or resume training:**
    ```sh
-   python src/training/alphazero_trainer.py
+   python run.py train --config configs/config.v2.yaml
    ```
-4. **Launch the web GUI:**
+4. **Evaluate a model:**
    ```sh
-  python chess_web_gui.py
-  ```
+   python run.py eval models/alpha_zero_checkpoints/latest_player.pt --games 5
+   ```
+5. **Launch the web GUI:**
+   ```sh
+   python run.py web
+   ```
 
 ## Recommended Settings
 - The default configuration trains a ~64M parameter model with 384 CNN channels and 20 residual blocks.

--- a/run.py
+++ b/run.py
@@ -9,6 +9,7 @@ training, evaluation, data generation, and environment checks.
 import argparse
 import sys
 import os
+import subprocess
 
 # (Removed obsolete sys.path manipulation after package installation)
 
@@ -48,6 +49,42 @@ def test_environment(config):
         print(f"Error details: {traceback.format_exc()}")
         sys.exit(1)
 
+
+def train_model(args):
+    """Entry point for the 'train' subcommand."""
+    from src.training.alphazero_trainer import AlphaZeroTrainer
+
+    trainer = AlphaZeroTrainer(config_path=args.config)
+    trainer.run()
+
+
+def evaluate_models(args):
+    """Run the evaluation script with provided arguments."""
+    cmd = [
+        sys.executable,
+        "evaluate_model.py",
+        *args.models,
+        "--mode",
+        args.mode,
+        "--games",
+        str(args.games),
+        "--stockfish_depth",
+        str(args.stockfish_depth),
+        "--mcts_sims",
+        str(args.mcts_sims),
+        "--time_limit",
+        str(args.time_limit),
+        "--device",
+        args.device,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def launch_web_gui(args):
+    """Launch the Flask-based chess web GUI."""
+    cmd = [sys.executable, "chess_web_gui.py"]
+    subprocess.run(cmd, check=True)
+
 def main():
     """
     Main function to parse arguments and run commands.
@@ -61,16 +98,78 @@ def main():
     )
     
     subparsers = parser.add_subparsers(dest="command", required=True)
-    
+
     # Test environment command
-    test_parser = subparsers.add_parser("test_env", help="Test the chess environment and dependencies.")
+    test_parser = subparsers.add_parser(
+        "test_env", help="Test the chess environment and dependencies."
+    )
     test_parser.set_defaults(func=test_environment)
-    
+
+    # Training command
+    train_parser = subparsers.add_parser(
+        "train", help="Run AlphaZero training using alphazero_trainer."
+    )
+    train_parser.set_defaults(func=train_model)
+
+    # Evaluation command
+    eval_parser = subparsers.add_parser(
+        "eval", help="Evaluate models using evaluate_model.py."
+    )
+    eval_parser.add_argument(
+        "models",
+        nargs="+",
+        help="Paths to model checkpoint files (.pt).",
+    )
+    eval_parser.add_argument(
+        "--mode",
+        type=str,
+        default="stockfish",
+        choices=["stockfish", "model"],
+        help="Evaluation mode: 'stockfish' or 'model' vs model.",
+    )
+    eval_parser.add_argument(
+        "--games", type=int, default=10, help="Number of games to play."
+    )
+    eval_parser.add_argument(
+        "--stockfish-depth",
+        type=int,
+        default=5,
+        help="Stockfish search depth.",
+    )
+    eval_parser.add_argument(
+        "--mcts-sims",
+        type=int,
+        default=50,
+        help="MCTS simulations per move.",
+    )
+    eval_parser.add_argument(
+        "--time-limit",
+        type=float,
+        default=1.0,
+        help="Time per move for Stockfish.",
+    )
+    eval_parser.add_argument(
+        "--device",
+        type=str,
+        default="auto",
+        help="Device to use (e.g., 'cuda', 'cpu').",
+    )
+    eval_parser.set_defaults(func=evaluate_models)
+
+    # Web GUI command
+    web_parser = subparsers.add_parser(
+        "web", help="Launch the chess web GUI."
+    )
+    web_parser.set_defaults(func=launch_web_gui)
+
     args = parser.parse_args()
-    
-    config = load_config(args.config)
-    
-    args.func(config)
+
+    if args.command == "test_env":
+        config = load_config(args.config)
+        args.func(config)
+    else:
+        args.func(args)
+
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
## Summary
- Extend `run.py` with `train`, `eval`, and `web` subcommands
- Add helper functions to run training, evaluation, and the Flask web GUI
- Document CLI usage in README

## Testing
- `pytest tests/test_move_encoder.py tests/test_mcts.py tests/test_replay_buffer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d62ce9f88323a4244cd9736d7f53