### PR TITLE
Fix CI workflow indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
+---
 name: CI
 
-on:
+'on':
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
@@ -17,9 +18,9 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-      run: |
-            python -m pip install --upgrade pip
-            pip install -e .[dev]
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
 
       - name: Run tests
-        run: pytest -q 
+        run: pytest -q


### PR DESCRIPTION
## Summary
- fix `Install dependencies` run block indentation in CI workflow
- quote `on` and clean branch list to satisfy yamllint

## Testing
- `yamllint .github/workflows/ci.yml`
- `pip install -e .[dev]`
- `pytest -q` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6896d63189a08323a54c7455480e3375